### PR TITLE
Define to_hash method to retain behavior of normal hash

### DIFF
--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -43,6 +43,10 @@ class Hashugar
     end
   end
 
+  def empty?
+    @table.empty?
+  end
+
   private
   def stringify(key)
     key.is_a?(Symbol) ? key.to_s : key

--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -29,7 +29,7 @@ class Hashugar
   end
 
   def respond_to?(key)
-    @table.has_key?(stringify(key))
+    super(key) || @table.has_key?(stringify(key))
   end
 
   def each(&block)

--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -36,6 +36,13 @@ class Hashugar
     @table_with_original_keys.each(&block)
   end
 
+  def to_hash
+    hash = @table_with_original_keys.to_hash
+    hash.each do |key, value|
+      hash[key] = value.to_hash if value.is_a?(Hashugar)
+    end
+  end
+
   private
   def stringify(key)
     key.is_a?(Symbol) ? key.to_s : key

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -92,7 +92,7 @@ describe Hashugar do
 
   describe '#to_hash' do
     it 'responds to to_hash' do
-      expect(Hashugar.new({}).respond_to?(:to_hash)).to eq(true)
+      expect(Hashugar.new({}).respond_to?(:to_hash)).to be true
     end
     it 'returns the original hash' do
       hashugar = Hashugar.new({:a => 4, :c => 2})
@@ -104,6 +104,15 @@ describe Hashugar do
         hashugar = Hashugar.new({ nested: { a: 4, c: 2 } })
         expect(hashugar.to_hash[:nested]).to eq({:a => 4, :c => 2})
       end
+    end
+  end
+
+  describe '#empty?' do
+    it 'behaves like the original hash' do
+      empty_hashugar = Hashugar.new({})
+      hashugar = Hashugar.new({a: 1})
+      expect(empty_hashugar.empty?).to be true
+      expect(hashugar.empty?).to be false
     end
   end
 end

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -91,6 +91,9 @@ describe Hashugar do
   end
 
   describe '#to_hash' do
+    it 'responds to to_hash' do
+      expect(Hashugar.new({}).respond_to?(:to_hash)).to eq(true)
+    end
     it 'returns the original hash' do
       hashugar = Hashugar.new({:a => 4, :c => 2})
       expect(hashugar.to_hash).to eq({:a => 4, :c => 2})

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -89,4 +89,18 @@ describe Hashugar do
       expect(values).to eq([4, 2])
     end
   end
+
+  describe '#to_hash' do
+    it 'returns the original hash' do
+      hashugar = Hashugar.new({:a => 4, :c => 2})
+      expect(hashugar.to_hash).to eq({:a => 4, :c => 2})
+    end
+
+    context 'when containing nested hashugar' do
+      it 'returns the original hash' do
+        hashugar = Hashugar.new({ nested: { a: 4, c: 2 } })
+        expect(hashugar.to_hash[:nested]).to eq({:a => 4, :c => 2})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This update is to retain the behavior of `Hash#to_hash` and `Hash#as_json` (for Rails)