### PR TITLE
Fix `respond_to?` method signature

### DIFF
--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -28,7 +28,7 @@ class Hashugar
     @table[stringify(key)] = value
   end
 
-  def respond_to?(key)
+  def respond_to?(key, include_all=false)
     super(key) || @table.has_key?(stringify(key))
   end
 


### PR DESCRIPTION
As of Ruby 2.0.0, the Ruby interpreter now gives a warning message when
`respond_to?` is used with the deprecated method signature (taking one
argument). As of version 2.0.0, the second argument is `include_all`, meaning that it should include private methods, which defaults to false. You can see this in the Ruby source
[here](https://github.com/ruby/ruby/blob/ruby_2_0_0/vm_method.c#L1578-L1579). This PR adds that second parameter and defaults it to false to stop the
warnings.