### PR TITLE
Update to_hash to returns normal hash with changes

### DIFF
--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -37,10 +37,11 @@ class Hashugar
   end
 
   def to_hash
-    hash = @table_with_original_keys.to_hash
-    hash.each do |key, value|
-      hash[key] = value.to_hash if value.is_a?(Hashugar)
+    hash = {}
+    @table.each_pair do |key, value|
+      hash[symbolize(key)] = value.is_a?(Hashugar) ? value.to_hash : value
     end
+    hash
   end
 
   def empty?
@@ -50,6 +51,10 @@ class Hashugar
   private
   def stringify(key)
     key.is_a?(Symbol) ? key.to_s : key
+  end
+
+  def symbolize(key)
+    key.to_s.to_sym
   end
 end
 

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -94,13 +94,20 @@ describe Hashugar do
     it 'responds to to_hash' do
       expect(Hashugar.new({}).respond_to?(:to_hash)).to be true
     end
-    it 'returns the original hash' do
-      hashugar = Hashugar.new({:a => 4, :c => 2})
+
+    it 'returns normal hash with all keys as symbol' do
+      hashugar = Hashugar.new({:a => 4, 'c' => 2})
       expect(hashugar.to_hash).to eq({:a => 4, :c => 2})
     end
 
+    it 'returns normal hash with changes' do
+      hashugar = Hashugar.new({:a => 4, :c => 2 })
+      hashugar.b = 5
+      expect(hashugar.to_hash).to eq({:a => 4, :b => 5, :c => 2})
+    end
+
     context 'when containing nested hashugar' do
-      it 'returns the original hash' do
+      it 'returns normal hash for nested hashugar' do
         hashugar = Hashugar.new({ nested: { a: 4, c: 2 } })
         expect(hashugar.to_hash[:nested]).to eq({:a => 4, :c => 2})
       end


### PR DESCRIPTION
This PR is to fix the issue reported in https://github.com/jsuchal/hashugar/pull/10 

Expected behaviors of `to_hash`
- Converting current hashugar object to normal hash with all keys as symbol.
- Converting nested hashugar object to nested normal hash.
