### PR TITLE
Improve inspect

### DIFF
--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -47,7 +47,12 @@ class Hashugar
     @table.empty?
   end
 
+  def inspect
+    "#<#{self.class} #{to_hash.inspect}>"
+  end
+
   private
+
   def stringify(key)
     key.is_a?(Symbol) ? key.to_s : key
   end

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -115,4 +115,11 @@ describe Hashugar do
       expect(hashugar.empty?).to be false
     end
   end
+
+  describe '#inspect' do
+    it 'prints the original hash' do
+      hashugar = Hashugar.new({a: { b: 1}})
+      expect(hashugar.inspect).to eq('#<Hashugar {:a=>{:b=>1}}>')
+    end
+  end
 end


### PR DESCRIPTION
With this change, `inspect` prints a succinct representation of the original hash so it looks a lot better in console. There's no information loss.

```ruby
Hashugar.new({a: { b: 1}}).inspect

# Old
#<Hashugar:0x00007fad2e870b58 @table={\"a\"=>#<Hashugar:0x00007fad2e861ae0 @table={\"b\"=>1}, @table_with_original_keys={:b=>1}>}, @table_with_original_keys={:a=>#<Hashugar:0x00007fad2e861ae0 @table={\"b\"=>1}, @table_with_original_keys={:b=>1}>}>

# New
#<Hashugar {:a=>{:b=>1}}>
```
