### PR TITLE
Unify two tables

### DIFF
--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -3,41 +3,42 @@ require "hashugar/version"
 class Hashugar
   def initialize(hash)
     @table = {}
-    @table_with_original_keys = {}
     hash.each_pair do |key, value|
-      hashugar = value.to_hashugar
-      @table_with_original_keys[key] = hashugar
-      @table[stringify(key)] = hashugar
+      @table[key] = value.to_hashugar
     end
   end
 
   def method_missing(method, *args, &block)
     method = method.to_s
     if method.chomp!('=')
-      @table[method] = args.first
+      self[method] = args.first
     else
-      @table[method]
+      self[method]
     end
   end
 
   def [](key)
-    @table[stringify(key)]
+    @table[key.to_s] || @table[key.to_sym]
   end
 
   def []=(key, value)
-    @table[stringify(key)] = value
+    if @table.has_key?(key.to_s)
+      @table[key.to_s] = value
+    else
+      @table[key] = value
+    end
   end
 
   def respond_to?(key, include_all=false)
-    super(key) || @table.has_key?(stringify(key))
+    super || @table.has_key?(key.to_s) || @table.has_key?(key.to_sym)
   end
 
   def each(&block)
-    @table_with_original_keys.each(&block)
+    @table.each(&block)
   end
 
   def to_hash
-    hash = @table_with_original_keys.to_hash
+    hash = @table.to_hash
     hash.each do |key, value|
       hash[key] = value.to_hash if value.is_a?(Hashugar)
     end
@@ -49,12 +50,6 @@ class Hashugar
 
   def inspect
     "#<#{self.class} #{to_hash.inspect}>"
-  end
-
-  private
-
-  def stringify(key)
-    key.is_a?(Symbol) ? key.to_s : key
   end
 end
 

--- a/lib/hashugar.rb
+++ b/lib/hashugar.rb
@@ -25,7 +25,7 @@ class Hashugar
     if @table.has_key?(key.to_s)
       @table[key.to_s] = value
     else
-      @table[key] = value
+      @table[key.to_sym] = value
     end
   end
 

--- a/spec/hashugar_spec.rb
+++ b/spec/hashugar_spec.rb
@@ -35,6 +35,13 @@ describe Hashugar do
       hashugar[:a] = 3
       expect(hashugar.a).to eq(3)
     end
+
+    it 'should be writable with original keys' do
+      hashugar = {:a => 1, 'b' => 2}.to_hashugar
+      hashugar.a = 100
+      hashugar.b = 200
+      expect(hashugar.to_hash).to eq({:a => 100, 'b' => 200})
+    end
   end
 
   context 'when accessing nested hash' do


### PR DESCRIPTION
This change will unify `@table` and `@table_with_original_keys` into one `@table` to:

* Keep original keys (string or symbol)
* Mutate contents with original keys
* Or if original key doesn't exist, add a new entry with string key

I believe overhead of `String#to_s` and `Symbol#to_sym` should be negligible, therefore it's a good trade-off for using 1/2 memory.